### PR TITLE
Optimizing waveform generation functions

### DIFF
--- a/esfm.c
+++ b/esfm.c
@@ -196,12 +196,6 @@ static int13
 ESFM_envelope_calc_sin0(uint10 phase, uint10 envelope)
 {
 	uint16 out = 0;
-	int13 neg = 1;
-	phase &= 0x3ff;
-	if (phase & 0x200)
-	{
-		neg = -1;
-	}
 	if (phase & 0x100)
 	{
 		out = logsinrom[(phase & 0xff) ^ 0xff];
@@ -210,7 +204,8 @@ ESFM_envelope_calc_sin0(uint10 phase, uint10 envelope)
 	{
 		out = logsinrom[phase & 0xff];
 	}
-	return ESFM_envelope_calc_exp(out + (envelope << 3)) * neg;
+	return (phase & 0x200) ? ESFM_envelope_calc_exp(out + (envelope << 3))
+		: -ESFM_envelope_calc_exp(out + (envelope << 3));
 }
 
 /* ------------------------------------------------------------------------- */
@@ -218,7 +213,6 @@ static int13
 ESFM_envelope_calc_sin1(uint10 phase, uint10 envelope)
 {
 	uint16 out = 0;
-	phase &= 0x3ff;
 	if (phase & 0x200)
 	{
 		out = 0x1000;
@@ -256,7 +250,6 @@ static int13
 ESFM_envelope_calc_sin3(uint10 phase, uint10 envelope)
 {
 	uint16 out = 0;
-	phase &= 0x3ff;
 	if (phase & 0x100)
 	{
 		out = 0x1000;
@@ -273,12 +266,6 @@ static int13
 ESFM_envelope_calc_sin4(uint10 phase, uint10 envelope)
 {
 	uint16 out = 0;
-	int13 neg = 1;
-	phase &= 0x3ff;
-	if ((phase & 0x300) == 0x100)
-	{
-		neg = -1;
-	}
 	if (phase & 0x200)
 	{
 		out = 0x1000;
@@ -291,7 +278,8 @@ ESFM_envelope_calc_sin4(uint10 phase, uint10 envelope)
 	{
 		out = logsinrom[(phase << 1) & 0xff];
 	}
-	return ESFM_envelope_calc_exp(out + (envelope << 3)) * neg;
+	return ((phase & 0x300) == 0x100) ? ESFM_envelope_calc_exp(out + (envelope << 3))
+		: -ESFM_envelope_calc_exp(out + (envelope << 3));
 }
 
 /* ------------------------------------------------------------------------- */
@@ -299,7 +287,6 @@ static int13
 ESFM_envelope_calc_sin5(uint10 phase, uint10 envelope)
 {
 	uint16 out = 0;
-	phase &= 0x3ff;
 	if (phase & 0x200)
 	{
 		out = 0x1000;
@@ -319,13 +306,8 @@ ESFM_envelope_calc_sin5(uint10 phase, uint10 envelope)
 static int13
 ESFM_envelope_calc_sin6(uint10 phase, uint10 envelope)
 {
-	int13 neg = 1;
-	phase &= 0x3ff;
-	if (phase & 0x200)
-	{
-		neg = -1;
-	}
-	return ESFM_envelope_calc_exp(envelope << 3) * neg;
+	return (phase & 0x200) ? ESFM_envelope_calc_exp(envelope << 3)
+		: -ESFM_envelope_calc_exp(envelope << 3);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -334,7 +316,6 @@ ESFM_envelope_calc_sin7(uint10 phase, uint10 envelope)
 {
 	uint16 out = 0;
 	int13 neg = 1;
-	phase &= 0x3ff;
 	if (phase & 0x200)
 	{
 		neg = -1;

--- a/esfm.h
+++ b/esfm.h
@@ -72,37 +72,6 @@ int16_t ESFM_get_channel_output_native(esfm_chip *chip, int channel_idx);
 
 // These are fake types just for syntax sugar.
 // Beware of their underlying types when reading/writing to them.
-#ifndef __NO_ESFM_FAST_TYPES
-#ifndef __ESFM_FAST_TYPES
-#define __ESFM_FAST_TYPES
-#endif
-#endif
-
-#ifdef __ESFM_FAST_TYPES
-
-typedef uint_fast8_t flag;
-typedef uint_fast8_t uint2;
-typedef uint_fast8_t uint3;
-typedef uint_fast8_t uint4;
-typedef uint_fast8_t uint5;
-typedef uint_fast8_t uint6;
-typedef uint_fast8_t uint8;
-typedef uint_fast16_t uint9;
-typedef uint_fast16_t uint10;
-typedef uint_fast16_t uint11;
-typedef uint_fast16_t uint12;
-typedef uint_fast16_t uint16;
-typedef uint_fast32_t uint19;
-typedef uint_fast32_t uint23;
-typedef uint_fast32_t uint32;
-typedef uint_fast64_t uint36;
-
-typedef int_fast16_t int13;
-typedef int_fast16_t int14;
-typedef int_fast16_t int16;
-typedef int_fast32_t int32;
-
-#else
 typedef uint8_t flag;
 typedef uint8_t uint2;
 typedef uint8_t uint3;
@@ -124,8 +93,6 @@ typedef int16_t int13;
 typedef int16_t int14;
 typedef int16_t int16;
 typedef int32_t int32;
-
-#endif
 
 enum eg_states
 {


### PR DESCRIPTION
- Optimizing performance of waveform calculation functions
- Removed "fast types" (benchmarked it; it gives no gains whatsoever and increases memory usage)

## Results

Roughly 3% reduction in CPU usage.