### PR TITLE
Patch envelope delay behavior

### DIFF
--- a/esfm.h
+++ b/esfm.h
@@ -174,7 +174,12 @@ typedef struct _esfm_slot_internal
 
 	uint2 eg_state;
 	flag eg_delay_run;
+	flag eg_delay_transitioned_10;
+	flag eg_delay_transitioned_10_gate;
+	flag eg_delay_transitioned_01;
+	flag eg_delay_transitioned_01_gate;
 	uint16 eg_delay_counter;
+	uint16 eg_delay_counter_compare;
 
 } esfm_slot_internal;
 

--- a/esfm_registers.c
+++ b/esfm_registers.c
@@ -365,6 +365,14 @@ ESFM_slot_write (esfm_slot *slot, uint8_t register_idx, uint8_t data)
 		ESFM_slot_update_keyscale(slot);
 		break;
 	case 0x05:
+		if (slot->env_delay < (data >> 5))
+		{
+			slot->in.eg_delay_transitioned_01 = 1;
+		}
+		else if (slot->env_delay > (data >> 5))
+		{
+			slot->in.eg_delay_transitioned_10 = 1;
+		}
 		slot->env_delay = data >> 5;
 		slot->emu_key_on = (data >> 5) & 0x01;
 		slot->block = (data >> 2) & 0x07;


### PR DESCRIPTION
Apparently, envelope delay can only transition upwards and downwards once.

I have no idea why or how. This needs to be investigated further, but for now this needs to be patched to be closer to real hardware.