### PR TITLE
Fix bugs in timer implementation

### DIFF
--- a/esfm.c
+++ b/esfm.c
@@ -2117,7 +2117,7 @@ ESFM_update_timers(esfm_chip *chip)
 	{
 		if (chip->timer_enable[i])
 		{
-			chip->timer_accumulator[i] += i == 0 ? TIMER1_CONST : TIMER2_CONST;
+			chip->timer_accumulator[i] += (i == 0) ? TIMER1_CONST : TIMER2_CONST;
 			if (chip->timer_accumulator[i] > 1.0)
 			{
 				chip->timer_accumulator[i] -= 1.0;
@@ -2126,6 +2126,7 @@ ESFM_update_timers(esfm_chip *chip)
 				{
 					if (chip->timer_mask[i] == 0)
 					{
+						chip->irq_bit = true;
 						chip->timer_overflow[i] = true;
 					}
 					chip->timer_counter[i] = chip->timer_reload[i];

--- a/esfm_registers.c
+++ b/esfm_registers.c
@@ -647,9 +647,11 @@ ESFM_write_reg_emu (esfm_chip *chip, uint16_t address, uint8_t data)
 				break;
 			case 0x02:
 				chip->timer_reload[0] = data;
+				chip->timer_counter[0] = data;
 				break;
 			case 0x03:
 				chip->timer_reload[1] = data;
+				chip->timer_counter[1] = data;
 				break;
 			case 0x04:
 				for (i = 0; i < 3; i++)
@@ -685,19 +687,24 @@ ESFM_write_reg_emu (esfm_chip *chip, uint16_t address, uint8_t data)
 				break;
 			case 0x02:
 				chip->timer_reload[0] = data;
+				chip->timer_counter[0] = data;
 				break;
 			case 0x03:
 				chip->timer_reload[1] = data;
+				chip->timer_counter[1] = data;
 				break;
 			case 0x04:
-				chip->timer_enable[0] = data & 0x01;
-				chip->timer_enable[1] = (data & 0x02) != 0;
-				chip->timer_mask[0] = (data & 0x20) != 0;
-				chip->timer_mask[1] = (data & 0x40) != 0;
 				if (data & 0x80)
 				{
 					chip->irq_bit = 0;
+					chip->timer_overflow[0] = 0;
+					chip->timer_overflow[1] = 0;
+					break;
 				}
+				chip->timer_enable[0] = data & 0x01;
+				chip->timer_enable[1] = (data & 0x02) != 0;
+				chip->timer_mask[1] = (data & 0x20) != 0;
+				chip->timer_mask[0] = (data & 0x40) != 0;
 				break;
 			case 0x08:
 				chip->keyscale_mode = (data & 0x40) != 0;


### PR DESCRIPTION
- IRQ bit wasn't being set upon timer overflow
- Writing to the timer value registers was only setting the timer reload registers, not the timer counter itself
- Timer mask bits were swapped
- Clearing the IRQ bit wasn't clearing the timer overflow bits
- Writing to 0x04 to clear the IRQ bit was affecting the other bits in the register when it shouldn't