### PR TITLE
Suppress compiler warnings from extraneous variables when compiling with inline ASM

### DIFF
--- a/esfm.c
+++ b/esfm.c
@@ -1741,6 +1741,10 @@ ESFM_slot_generate_emu(esfm_slot *slot)
 }
 
 /* ------------------------------------------------------------------------- */
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 static void
 ESFM_process_feedback(esfm_chip *chip)
 {


### PR DESCRIPTION
Before:
```
$ gcc -Wall -Wextra -o /dev/null -c esfm.c
esfm.c: In function ‘ESFM_process_feedback’:
esfm.c:1760:26: warning: unused variable ‘phase’ [-Wunused-variable]
 1760 |                 uint32_t phase, phase_acc;
      |                          ^~~~~
esfm.c:1757:26: warning: unused variable ‘iter_counter’ [-Wunused-variable]
 1757 |                 uint32_t iter_counter;
      |                          ^~~~~~~~~~~~
esfm.c:1755:35: warning: unused variable ‘wave_last’ [-Wunused-variable]
 1755 |                 int32_t wave_out, wave_last;
      |
$
```

After:
```
$ gcc -Wall -Wextra -o /dev/null -c esfm.c
$
```